### PR TITLE
Drop database if it already exists in setup script for db.

### DIFF
--- a/backend/database_config/create_database_script.sql
+++ b/backend/database_config/create_database_script.sql
@@ -1,4 +1,4 @@
-DROP DATABASE flatM8s;
+DROP DATABASE IF EXISTS flatM8s ;
 
 /*
 run this file in mySQL Workbench to create the database with some init data to test with


### PR DESCRIPTION
This is so when you run the script for the first time it won't fail

with the error 
```
Can't drop database 'flatM8s'; database doesn't exist
```